### PR TITLE
Add from_query classmethod for AflowPrototype

### DIFF
--- a/fedorov/fedorov.py
+++ b/fedorov/fedorov.py
@@ -1249,6 +1249,47 @@ class AflowPrototype(Prototype):
             base += 1
         return wyckoff_sites, wyckoff_positions, type_by_site
 
+    @classmethod
+    def from_query(
+        cls,
+        pearson_symbol: "str | None" = None,
+        space_group: "int | None" = None,
+        prototype: "str | None" = None,
+        set_type: bool = False,
+    ):
+        """Create all `AflowPrototype` matching the given query.
+
+        Args:
+            pearson_symbol (`str`, optional): The Pearson symbol to search for,
+                defaults to ``None`` which accepts any Pearson symbol.
+            space_group (`int`, optional): The space group to search for,
+                defaults to ``None`` which accepts any space group.
+            prototype (`str`, optional): The chemical prototype to search for,
+                defaults to ``None`` which accepts any prototype.
+            set_type (`bool`, optional): Set different type name (in alphabetic
+                order starting with "A") for different atoms in AFLOW prototype.
+
+        Returns:
+            lattices (list[`AflowPrototype`]): The list of all
+                `AflowPrototype`'s with a given Pearson symbol.
+        """
+
+        def query(row):
+            return (
+                (prototype is None or row.prototype == prototype)
+                and (
+                    pearson_symbol is None
+                    or row.pearson_symbol == pearson_symbol
+                )
+                and (space_group is None or row.space_group == space_group)
+            )
+
+        return [
+            cls(i, set_type)
+            for i, row in cls._Aflow_database.iterrows()
+            if query(row)
+        ]
+
 
 # Point Group operations
 class PointGroup:

--- a/fedorov/fedorov.py
+++ b/fedorov/fedorov.py
@@ -1206,6 +1206,8 @@ class AflowPrototype(Prototype):
         )
 
         self.id = entry["id"]
+        self.pearson_symbol = entry["pearson_symbol"]
+        self.prototype = entry["prototype"]
         self.space_group_number = space_group
         self.space_group = SpaceGroup(space_group)
         self.wyckoff_site_list = wyckoff_sites

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -108,6 +108,36 @@ class TestAflowPrototype:
         if type_list is not None:
             assert type_list == struct_type_list
 
+    @pytest.mark.parametrize(
+        "query, expected_length",
+        [
+            ({"pearson_symbol": "cP8"}, 7),
+            ({"pearson_symbol": "cP8", "prototype": "N"}, 2),
+            ({"pearson_symbol": "cP8", "space_group": 198}, 3),
+            (
+                {"pearson_symbol": "cP8", "space_group": 198, "prototype": "N"},
+                1,
+            ),
+            ({"pearson_symbol": "hP2", "space_group": 194}, 1),
+            ({"space_group": 198}, 6),
+        ],
+    )
+    def test_from_query(self, query, expected_length):
+        structures = fedorov.AflowPrototype.from_query(**query)
+        assert len(structures) == expected_length
+        if "pearson_symbol" in query:
+            assert all(
+                st.pearson_symbol == query["pearson_symbol"]
+                for st in structures
+            )
+        if "space_group" in query:
+            assert all(
+                st.space_group_number == query["space_group"]
+                for st in structures
+            )
+        if "prototype" in query:
+            assert all(st.prototype == query["prototype"] for st in structures)
+
 
 def test_prototype():
     structure = Prototype(


### PR DESCRIPTION
Merge after #11.

Adds the ability to query the Aflow database via Pearson symbol, space group, and prototype (chemical makeup).